### PR TITLE
Baseline implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ const ramda_0230 = require('ramda@0.23.0');
 const ramda_023x = require('ramda@0.23.x');
 const ramda_latest = require('ramda@latest');
 ```
+> __PROTIP:__ Any valid semver query that is also a valid \*nix directory name is supported.
 
 ## Maintainers
 * Rocky Madden ([@rockymadden](https://github.com/rockymadden))

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# multi-tool <sub><sup>| Install packages wrapped to be multi-version friendly</sup></sub>
+# multi-tool <sub><sup>| Install multiple versions of any NPM package via semver ranges<sup></sub>
 [![version](http://img.shields.io/badge/version-0.0.0-blue.svg)](https://www.npmjs.com/package/@cloudelements/multi-tool)
 [![versioning](http://img.shields.io/badge/versioning-semver-blue.svg)](http://semver.org/)
 [![branching](http://img.shields.io/badge/branching-github%20flow-blue.svg)](https://guides.github.com/introduction/flow/)
@@ -22,7 +22,7 @@ const ramda_0230 = require('ramda@0.23.0');
 const ramda_023x = require('ramda@0.23.x');
 const ramda_latest = require('ramda@latest');
 ```
-> __PROTIP:__ Any valid semver query that is also a valid \*nix directory name is supported.
+> __PROTIP:__ Any valid semver range that is also a valid \*nix directory name is supported.
 
 ## Maintainers
 * Rocky Madden ([@rockymadden](https://github.com/rockymadden))

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![styling](http://img.shields.io/badge/code%20styling-XO-blue.svg)](https://github.com/sindresorhus/xo)
 [![build](https://circleci.com/gh/cloud-elements/multi-tool.svg?style=shield)](https://circleci.com/gh/cloud-elements/multi-tool)
 
-## Installation
+## Install
 ```javascript
 $ npm install --save multi-tool
 ```

--- a/README.md
+++ b/README.md
@@ -15,8 +15,10 @@ $ npm install --save multi-tool
 const multitool = require('multi-tool');
 
 await multitool('ramda', '0.23.0');
+await multitool('ramda', '0.23.x');
 
-const {identity} = require('ramda@0.23.0');
+const ramda0230 = require('ramda@0.23.0');
+const ramda023x = require('ramda@0.23.x');
 ```
 
 ## Maintainers

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# multi-tool <sub><sup>| Install multiple versions of any NPM package via semver ranges<sup></sub>
+# multi-tool <sub><sup>| Install multiple versions of NPM packages via semver ranges<sup></sub>
 [![version](http://img.shields.io/badge/version-0.0.0-blue.svg)](https://www.npmjs.com/package/@cloudelements/multi-tool)
 [![versioning](http://img.shields.io/badge/versioning-semver-blue.svg)](http://semver.org/)
 [![branching](http://img.shields.io/badge/branching-github%20flow-blue.svg)](https://guides.github.com/introduction/flow/)

--- a/README.md
+++ b/README.md
@@ -10,5 +10,14 @@
 $ npm install --save multi-tool
 ```
 
+## Usage
+```javascript
+const multitool = require('multitool');
+
+await multitool('node_modules', 'ramda', '0.23.0');
+
+const {identity} = require('ramda@0.23.0');
+```
+
 ## Maintainers
 * Rocky Madden ([@rockymadden](https://github.com/rockymadden))

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ $ npm install --save multi-tool
 
 ## Usage
 ```javascript
-const multitool = require('multitool');
+const multitool = require('multi-tool');
 
 await multitool('ramda', '0.23.0');
 

--- a/README.md
+++ b/README.md
@@ -16,9 +16,11 @@ const multitool = require('multi-tool');
 
 await multitool('ramda', '0.23.0');
 await multitool('ramda', '0.23.x');
+await multitool('ramda', 'latest');
 
-const ramda0230 = require('ramda@0.23.0');
-const ramda023x = require('ramda@0.23.x');
+const ramda_0230 = require('ramda@0.23.0');
+const ramda_023x = require('ramda@0.23.x');
+const ramda_latest = require('ramda@latest');
 ```
 
 ## Maintainers

--- a/README.md
+++ b/README.md
@@ -12,11 +12,11 @@ $ npm install --save multi-tool
 
 ## Usage
 ```javascript
-const multitool = require('multi-tool');
+const install = require('multi-tool');
 
-await multitool('ramda', '0.23.0');
-await multitool('ramda', '0.23.x');
-await multitool('ramda', 'latest');
+await install('ramda', '0.23.0');
+await install('ramda', '0.23.x');
+await install('ramda', 'latest');
 
 const ramda_0230 = require('ramda@0.23.0');
 const ramda_023x = require('ramda@0.23.x');

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ $ npm install --save multi-tool
 ```javascript
 const multitool = require('multitool');
 
-await multitool('node_modules', 'ramda', '0.23.0');
+await multitool('ramda', '0.23.0');
 
 const {identity} = require('ramda@0.23.0');
 ```

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "multiple",
     "npm",
     "package",
-    "packages"
+    "packages",
     "semver",
     "version",
     "versioning"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "pify": "2.x",
     "valid-filename": "2.x"
   },
-  "description": "Install packages wrapped to be multi-version friendly",
+  "description": "Install multiple versions of any NPM package via semver ranges",
   "devDependencies": {
     "ava": "0.17.x",
     "nyc": "10.x",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,8 @@
   "xo": {
     "esnext": true,
     "rules": {
-      "import/no-extraneous-dependencies": 0
+      "import/no-extraneous-dependencies": 0,
+      "import/no-unresolved": 0
     },
     "space": 2
   }

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
     "mkdirp": "0.5.x",
     "pify": "2.x",
     "ramda": "0.23.x",
+    "valid-filename": "2.x",
     "write-file-atomic": "1.x"
   },
   "description": "Install packages wrapped to be multi-version friendly",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "dependencies": {
     "execa": "0.6.x",
+    "findup-sync": "0.4.x",
     "fs-extra": "2.x",
     "pify": "2.x",
     "valid-filename": "2.x"

--- a/package.json
+++ b/package.json
@@ -14,6 +14,16 @@
   },
   "engines": {"node": ">=7.0.0"},
   "homepage": "https://github.com/cloud-elements/multi-tool",
+  "keywords": [
+    "install",
+    "multiple",
+    "npm",
+    "package",
+    "packages"
+    "semver",
+    "version",
+    "versioning"
+  ],
   "license": "ISC",
   "main": "src/index.js",
   "name": "multi-tool",

--- a/package.json
+++ b/package.json
@@ -13,9 +13,7 @@
     "nyc": "10.x",
     "xo": "0.17.x"
   },
-  "engines" : {
-    "node" : ">=7.0.0"
-  },
+  "engines": {"node": ">=7.0.0"},
   "homepage": "https://github.com/cloud-elements/multi-tool",
   "license": "ISC",
   "main": "src/index.js",
@@ -43,7 +41,8 @@
     "esnext": true,
     "rules": {
       "import/no-extraneous-dependencies": 0,
-      "import/no-unresolved": 0
+      "import/no-unresolved": 0,
+      "new-cap": 0
     },
     "space": 2
   }

--- a/package.json
+++ b/package.json
@@ -4,8 +4,7 @@
     "mkdirp": "0.5.x",
     "pify": "2.x",
     "ramda": "0.23.x",
-    "write-file-atomic": "1.x",
-    "write-pkg": "2.x"
+    "write-file-atomic": "1.x"
   },
   "description": "Install packages wrapped to be multi-version friendly",
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "pify": "2.x",
     "valid-filename": "2.x"
   },
-  "description": "Install multiple versions of any NPM package via semver ranges",
+  "description": "Install multiple versions of NPM packages via semver ranges",
   "devDependencies": {
     "ava": "0.17.x",
     "nyc": "10.x",

--- a/package.json
+++ b/package.json
@@ -1,9 +1,10 @@
 {
   "dependencies": {
+    "app-root-path": "2.x",
     "execa": "0.6.x",
+    "find-node-modules": "1.x",
     "fs-extra": "2.x",
     "pify": "2.x",
-    "ramda": "0.23.x",
     "valid-filename": "2.x"
   },
   "description": "Install packages wrapped to be multi-version friendly",

--- a/package.json
+++ b/package.json
@@ -1,10 +1,11 @@
 {
   "dependencies": {
     "execa": "0.6.x",
-    "graceful-fs": "4.x",
     "mkdirp": "0.5.x",
     "pify": "2.x",
-    "ramda": "0.23.x"
+    "ramda": "0.23.x",
+    "write-file-atomic": "1.x",
+    "write-pkg": "2.x"
   },
   "description": "Install packages wrapped to be multi-version friendly",
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -41,6 +41,9 @@
   "version": "0.0.0",
   "xo": {
     "esnext": true,
+    "rules": {
+      "import/no-extraneous-dependencies": 0
+    },
     "space": 2
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,8 +1,6 @@
 {
   "dependencies": {
-    "app-root-path": "2.x",
     "execa": "0.6.x",
-    "find-node-modules": "1.x",
     "fs-extra": "2.x",
     "pify": "2.x",
     "valid-filename": "2.x"

--- a/package.json
+++ b/package.json
@@ -1,11 +1,10 @@
 {
   "dependencies": {
     "execa": "0.6.x",
-    "mkdirp": "0.5.x",
+    "fs-extra": "2.x",
     "pify": "2.x",
     "ramda": "0.23.x",
-    "valid-filename": "2.x",
-    "write-file-atomic": "1.x"
+    "valid-filename": "2.x"
   },
   "description": "Install packages wrapped to be multi-version friendly",
   "devDependencies": {

--- a/src/index.js
+++ b/src/index.js
@@ -4,9 +4,14 @@ const pth = require('path');
 const execa = require('execa');
 const mkdirp = require('mkdirp');
 const pify = require('pify');
+const validFilename = require('valid-filename');
 const writeFile = require('write-file-atomic');
 
 const install = async (path, name, version) => {
+  if (!validFilename(`${name}@${version}`)) {
+    return null;
+  }
+
   const dir = pth.join(path, `${name}@${version}`);
   const pkg = pth.join(dir, 'package.json');
   const js = pth.join(dir, 'index.js');
@@ -22,7 +27,7 @@ const install = async (path, name, version) => {
     await pify(mkdirp)(dir);
     await pify(writeFile)(pkg, pkgContents);
     await pify(writeFile)(js, jsContents);
-    await execa.shell(`cd ${dir} && npm install`);
+    await execa.shell(`cd '${dir}' && npm install`);
 
     return `${name}@${version}`;
   } catch (err) {

--- a/src/index.js
+++ b/src/index.js
@@ -2,12 +2,11 @@
 
 const pth = require('path');
 const execa = require('execa');
-const mkdirp = require('mkdirp');
+const fs = require('fs-extra');
 const pify = require('pify');
 const validFilename = require('valid-filename');
-const writeFile = require('write-file-atomic');
 
-const install = (sync, mkdir, mkfile, shell) => (path, name, version) => {
+const install = sync => (mkdir, mkfile, rmdir, shell) => (path, name, version) => {
   if (!validFilename(`${name}@${version}`)) {
     return null;
   }
@@ -25,30 +24,40 @@ const install = (sync, mkdir, mkfile, shell) => (path, name, version) => {
 
   if (sync) {
     try {
-      mkdirp(dir);
+      rmdir(dir);
+      mkdir(dir);
       mkfile(pkg, pkgContents);
       mkfile(js, jsContents);
       shell(`cd '${dir}' && npm install`);
 
       return `${name}@${version}`;
     } catch (err) {
+      try {
+        rmdir(dir);
+      } catch (err) { }
+
       return null;
     }
   } else {
     return (async () => {
       try {
-        await mkdirp(dir);
+        await rmdir(dir);
+        await mkdir(dir);
         await mkfile(pkg, pkgContents);
         await mkfile(js, jsContents);
         await shell(`cd '${dir}' && npm install`);
 
         return `${name}@${version}`;
       } catch (err) {
+        try {
+          rmdir(dir);
+        } catch (err) { }
+
         return null;
       }
     })();
   }
 };
 
-module.exports = install(false, pify(mkdirp), pify(writeFile), execa.shell);
-module.exports.sync = install(true, mkdirp.sync, writeFile.sync, execa.shellSync);
+module.exports = install(false)(pify(fs.mkdirp), pify(fs.outputFile), pify(fs.remove), execa.shell);
+module.exports.sync = install(true)(fs.mkdirpSync, fs.outputFileSync, fs.removeSync, execa.shellSync);

--- a/src/index.js
+++ b/src/index.js
@@ -1,8 +1,31 @@
 'use strict';
 
-const path = require('path');
+const pth = require('path');
+const execa = require('execa');
+const mkdirp = require('mkdirp');
 const pify = require('pify');
+const writeFile = require('write-file-atomic');
+const writePkg = require('write-pkg');
 
 module.exports = async (path, name, version) => {
+  const fullname = `${name}-${version}`;
+  const dir = pth.join(path, fullname);
+  const pkg = pth.join(dir, 'package.json');
+  const idx = pth.join(dir, 'index.js');
 
+  try {
+    await pify(mkdirp)(dir);
+    await writePkg(pkg, {
+      name: fullname,
+      version: '0.0.0',
+      main: 'index.js',
+      dependencies: {[name]: version}
+    });
+    await pify(writeFile)(idx, `module.exports = require('${name}');`);
+    await execa.shell(`cd ${dir} && npm install`);
+
+    return fullname;
+  } catch (err) {
+    return null;
+  }
 };

--- a/src/index.js
+++ b/src/index.js
@@ -5,24 +5,23 @@ const execa = require('execa');
 const mkdirp = require('mkdirp');
 const pify = require('pify');
 const writeFile = require('write-file-atomic');
-const writePkg = require('write-pkg');
 
 const install = async (path, name, version) => {
   const dir = pth.join(path, `${name}@${version}`);
   const pkg = pth.join(dir, 'package.json');
-  const idx = pth.join(dir, 'index.js');
-  const pkgContents = {
+  const js = pth.join(dir, 'index.js');
+  const pkgContents = JSON.stringify({
     name: `${name}-${version}`,
     version: '0.0.0',
     main: 'index.js',
     dependencies: {[name]: version}
-  };
-  const idxContents = `module.exports = require('${name}');`;
+  });
+  const jsContents = `module.exports = require('${name}');`;
 
   try {
     await pify(mkdirp)(dir);
-    await writePkg(pkg, pkgContents);
-    await pify(writeFile)(idx, idxContents);
+    await pify(writeFile)(pkg, pkgContents);
+    await pify(writeFile)(js, jsContents);
     await execa.shell(`cd ${dir} && npm install`);
 
     return `${name}@${version}`;

--- a/src/index.js
+++ b/src/index.js
@@ -2,6 +2,7 @@
 
 const pth = require('path');
 const execa = require('execa');
+const findup = require('findup-sync');
 const fs = require('fs-extra');
 const pify = require('pify');
 const validFilename = require('valid-filename');
@@ -14,6 +15,10 @@ const write = pify(fs.outputFile);
 const install = async (name, version, path) => {
   if (!validFilename(`${name}@${version}`)) {
     return null;
+  }
+
+  if (!path) {
+    path = findup('node_modules', {cwd: module.parent.filename});
   }
 
   const dir = pth.join(path, `${name}@${version}`);

--- a/src/index.js
+++ b/src/index.js
@@ -12,16 +12,18 @@ module.exports = async (path, name, version) => {
   const dir = pth.join(path, fullname);
   const pkg = pth.join(dir, 'package.json');
   const idx = pth.join(dir, 'index.js');
+  const pkgContents = {
+    name: fullname,
+    version: '0.0.0',
+    main: 'index.js',
+    dependencies: {[name]: version}
+  };
+  const idxContents = `module.exports = require('${name}');`;
 
   try {
     await pify(mkdirp)(dir);
-    await writePkg(pkg, {
-      name: fullname,
-      version: '0.0.0',
-      main: 'index.js',
-      dependencies: {[name]: version}
-    });
-    await pify(writeFile)(idx, `module.exports = require('${name}');`);
+    await writePkg(pkg, pkgContents);
+    await pify(writeFile)(idx, idxContents);
     await execa.shell(`cd ${dir} && npm install`);
 
     return fullname;

--- a/src/index.js
+++ b/src/index.js
@@ -7,7 +7,7 @@ const pify = require('pify');
 const validFilename = require('valid-filename');
 const writeFile = require('write-file-atomic');
 
-const installSync = (path, name, version) => {
+const install = (sync, mkdir, mkfile, shell) => (path, name, version) => {
   if (!validFilename(`${name}@${version}`)) {
     return null;
   }
@@ -23,45 +23,32 @@ const installSync = (path, name, version) => {
   });
   const jsContents = `module.exports = require('${name}');`;
 
-  try {
-    mkdirp.sync(dir);
-    writeFile.sync(pkg, pkgContents);
-    writeFile.sync(js, jsContents);
-    execa.shellSync(`cd '${dir}' && npm install`);
+  if (sync) {
+    try {
+      mkdirp(dir);
+      mkfile(pkg, pkgContents);
+      mkfile(js, jsContents);
+      shell(`cd '${dir}' && npm install`);
 
-    return `${name}@${version}`;
-  } catch (err) {
-    return null;
+      return `${name}@${version}`;
+    } catch (err) {
+      return null;
+    }
+  } else {
+    return (async () => {
+      try {
+        await mkdirp(dir);
+        await mkfile(pkg, pkgContents);
+        await mkfile(js, jsContents);
+        await shell(`cd '${dir}' && npm install`);
+
+        return `${name}@${version}`;
+      } catch (err) {
+        return null;
+      }
+    })();
   }
 };
 
-const installAsync = async (path, name, version) => {
-  if (!validFilename(`${name}@${version}`)) {
-    return null;
-  }
-
-  const dir = pth.join(path, `${name}@${version}`);
-  const pkg = pth.join(dir, 'package.json');
-  const js = pth.join(dir, 'index.js');
-  const pkgContents = JSON.stringify({
-    name: `${name}-${version}`,
-    version: '0.0.0',
-    main: 'index.js',
-    dependencies: {[name]: version}
-  });
-  const jsContents = `module.exports = require('${name}');`;
-
-  try {
-    await pify(mkdirp)(dir);
-    await pify(writeFile)(pkg, pkgContents);
-    await pify(writeFile)(js, jsContents);
-    await execa.shell(`cd '${dir}' && npm install`);
-
-    return `${name}@${version}`;
-  } catch (err) {
-    return null;
-  }
-};
-
-module.exports = installAsync;
-module.exports.sync = installSync;
+module.exports = install(false, pify(mkdirp), pify(writeFile), execa.shell);
+module.exports.sync = install(true, mkdirp.sync, writeFile.sync, execa.shellSync);

--- a/src/index.js
+++ b/src/index.js
@@ -8,12 +8,11 @@ const writeFile = require('write-file-atomic');
 const writePkg = require('write-pkg');
 
 const install = async (path, name, version) => {
-  const concatted = `${name}-${version}`;
-  const dir = pth.join(path, concatted);
+  const dir = pth.join(path, `${name}@${version}`);
   const pkg = pth.join(dir, 'package.json');
   const idx = pth.join(dir, 'index.js');
   const pkgContents = {
-    name: concatted,
+    name: `${name}-${version}`,
     version: '0.0.0',
     main: 'index.js',
     dependencies: {[name]: version}
@@ -26,7 +25,7 @@ const install = async (path, name, version) => {
     await pify(writeFile)(idx, idxContents);
     await execa.shell(`cd ${dir} && npm install`);
 
-    return concatted;
+    return `${name}@${version}`;
   } catch (err) {
     return null;
   }

--- a/src/index.js
+++ b/src/index.js
@@ -11,7 +11,7 @@ const rmdir = pify(fs.remove);
 const shell = execa.shell;
 const write = pify(fs.outputFile);
 
-const install = async (path, name, version) => {
+const install = async (name, version, path) => {
   if (!validFilename(`${name}@${version}`)) {
     return null;
   }

--- a/src/index.js
+++ b/src/index.js
@@ -17,21 +17,21 @@ const install = async (path, name, version) => {
   }
 
   const dir = pth.join(path, `${name}@${version}`);
-  const pkg = pth.join(dir, 'package.json');
+  const pkgPath = pth.join(dir, 'package.json');
   const pkgContents = JSON.stringify({
     name: `${name}-${version}`,
     version: '0.0.0',
     main: 'index.js',
     dependencies: {[name]: version}
   });
-  const js = pth.join(dir, 'index.js');
+  const jsPath = pth.join(dir, 'index.js');
   const jsContents = `module.exports = require('${name}');`;
 
   try {
     await rmdir(dir);
     await mkdir(dir);
-    await write(pkg, pkgContents);
-    await write(js, jsContents);
+    await write(pkgPath, pkgContents);
+    await write(jsPath, jsContents);
     await shell(`cd '${dir}' && npm install`);
 
     return `${name}@${version}`;

--- a/src/index.js
+++ b/src/index.js
@@ -8,7 +8,7 @@ const writeFile = require('write-file-atomic');
 const writePkg = require('write-pkg');
 
 module.exports = async (path, name, version) => {
-  const concatted = `${name}-${version}`;
+  const concatted = `${name}@${version}`;
   const dir = pth.join(path, concatted);
   const pkg = pth.join(dir, 'package.json');
   const idx = pth.join(dir, 'index.js');

--- a/src/index.js
+++ b/src/index.js
@@ -7,8 +7,8 @@ const pify = require('pify');
 const writeFile = require('write-file-atomic');
 const writePkg = require('write-pkg');
 
-module.exports = async (path, name, version) => {
-  const concatted = `${name}@${version}`;
+const install = async (path, name, version) => {
+  const concatted = `${name}-${version}`;
   const dir = pth.join(path, concatted);
   const pkg = pth.join(dir, 'package.json');
   const idx = pth.join(dir, 'index.js');
@@ -31,3 +31,5 @@ module.exports = async (path, name, version) => {
     return null;
   }
 };
+
+module.exports = install;

--- a/src/index.js
+++ b/src/index.js
@@ -18,13 +18,13 @@ const install = async (path, name, version) => {
 
   const dir = pth.join(path, `${name}@${version}`);
   const pkg = pth.join(dir, 'package.json');
-  const js = pth.join(dir, 'index.js');
   const pkgContents = JSON.stringify({
     name: `${name}-${version}`,
     version: '0.0.0',
     main: 'index.js',
     dependencies: {[name]: version}
   });
+  const js = pth.join(dir, 'index.js');
   const jsContents = `module.exports = require('${name}');`;
 
   try {

--- a/src/index.js
+++ b/src/index.js
@@ -8,12 +8,12 @@ const writeFile = require('write-file-atomic');
 const writePkg = require('write-pkg');
 
 module.exports = async (path, name, version) => {
-  const fullname = `${name}-${version}`;
-  const dir = pth.join(path, fullname);
+  const concatted = `${name}-${version}`;
+  const dir = pth.join(path, concatted);
   const pkg = pth.join(dir, 'package.json');
   const idx = pth.join(dir, 'index.js');
   const pkgContents = {
-    name: fullname,
+    name: concatted,
     version: '0.0.0',
     main: 'index.js',
     dependencies: {[name]: version}
@@ -26,7 +26,7 @@ module.exports = async (path, name, version) => {
     await pify(writeFile)(idx, idxContents);
     await execa.shell(`cd ${dir} && npm install`);
 
-    return fullname;
+    return concatted;
   } catch (err) {
     return null;
   }

--- a/test/index.js
+++ b/test/index.js
@@ -3,7 +3,7 @@
 const test = require('ava');
 const multitool = require('../src');
 
-test(async t => {
+test('installing a valid package with an exact version should return new package name', async t => {
   const install = await multitool('node_modules', 'ramda', '0.23.0');
 
   t.is(install, 'ramda-0.23.0');

--- a/test/index.js
+++ b/test/index.js
@@ -15,33 +15,9 @@ test.serial('installing a valid package with an exact version should work', asyn
   t.true(Maybe.isNothing(Maybe.Nothing()));
 });
 
-test.serial('synchronously installing a valid package with an exact version should work', t => {
-  const installed0 = multitool.sync('node_modules', 'ramda', '0.23.0');
-  const installed1 = multitool.sync('node_modules', 'ramda-fantasy', '0.7.0');
-  const {identity} = require('ramda@0.23.0');
-  const {Maybe} = require('ramda-fantasy@0.7.0');
-
-  t.is(installed0, 'ramda@0.23.0');
-  t.is(installed1, 'ramda-fantasy@0.7.0');
-  t.is(identity('hello'), 'hello');
-  t.true(Maybe.isNothing(Maybe.Nothing()));
-});
-
 test.serial('installing a valid package with an x-based query should work', async t => {
   const installed0 = await multitool('node_modules', 'ramda', '0.23.x');
   const installed1 = await multitool('node_modules', 'ramda-fantasy', '0.x');
-  const {identity} = require('ramda@0.23.x');
-  const {Maybe} = require('ramda-fantasy@0.x');
-
-  t.is(installed0, 'ramda@0.23.x');
-  t.is(installed1, 'ramda-fantasy@0.x');
-  t.is(identity('hello'), 'hello');
-  t.true(Maybe.isNothing(Maybe.Nothing()));
-});
-
-test.serial('synchronously installing a valid package with an x-based query should work', t => {
-  const installed0 = multitool.sync('node_modules', 'ramda', '0.23.x');
-  const installed1 = multitool.sync('node_modules', 'ramda-fantasy', '0.x');
   const {identity} = require('ramda@0.23.x');
   const {Maybe} = require('ramda-fantasy@0.x');
 
@@ -57,32 +33,14 @@ test.serial('installing an non-existent package should return null', async t => 
   t.is(installed, null);
 });
 
-test.serial('synchronously installing an non-existent package should return null', t => {
-  const installed = multitool.sync('node_modules', 'doesnt-exist', '0.0.0');
-
-  t.is(installed, null);
-});
-
 test.serial('installing an non-existent package version should return null', async t => {
   const installed = await multitool('node_modules', 'ramda', '99.99.99');
 
   t.is(installed, null);
 });
 
-test.serial('synchronously installing an non-existent package version should return null', t => {
-  const installed = multitool.sync('node_modules', 'ramda', '99.99.99');
-
-  t.is(installed, null);
-});
-
 test.serial('installing an invalidly named package should return null', async t => {
   const installed = await multitool('node_modules', 'ramda', '>=99.99.99');
-
-  t.is(installed, null);
-});
-
-test.serial('synchronously installing an invalidly named package should return null', t => {
-  const installed = multitool.sync('node_modules', 'ramda', '>=99.99.99');
 
   t.is(installed, null);
 });

--- a/test/index.js
+++ b/test/index.js
@@ -8,3 +8,10 @@ test('installing a valid package with an exact version should return new package
 
   t.is(install, 'ramda-0.23.0');
 });
+
+test('installing a valid package with an exact version should work', async t => {
+  await multitool('node_modules', 'ramda', '0.23.0');
+  const {identity} = require('ramda-0.23.0');
+
+  t.is(identity('hello'), 'hello');
+});

--- a/test/index.js
+++ b/test/index.js
@@ -15,9 +15,33 @@ test('installing a valid package with an exact version should work', async t => 
   t.true(Maybe.isNothing(Maybe.Nothing()));
 });
 
+test('synchronously installing a valid package with an exact version should work', t => {
+  const installed0 = multitool.sync('node_modules', 'ramda', '0.23.0');
+  const installed1 = multitool.sync('node_modules', 'ramda-fantasy', '0.7.0');
+  const {identity} = require('ramda@0.23.0');
+  const {Maybe} = require('ramda-fantasy@0.7.0');
+
+  t.is(installed0, 'ramda@0.23.0');
+  t.is(installed1, 'ramda-fantasy@0.7.0');
+  t.is(identity('hello'), 'hello');
+  t.true(Maybe.isNothing(Maybe.Nothing()));
+});
+
 test('installing a valid package with an x-based query should work', async t => {
   const installed0 = await multitool('node_modules', 'ramda', '0.23.x');
   const installed1 = await multitool('node_modules', 'ramda-fantasy', '0.x');
+  const {identity} = require('ramda@0.23.x');
+  const {Maybe} = require('ramda-fantasy@0.x');
+
+  t.is(installed0, 'ramda@0.23.x');
+  t.is(installed1, 'ramda-fantasy@0.x');
+  t.is(identity('hello'), 'hello');
+  t.true(Maybe.isNothing(Maybe.Nothing()));
+});
+
+test('synchronously installing a valid package with an x-based query should work', t => {
+  const installed0 = multitool.sync('node_modules', 'ramda', '0.23.x');
+  const installed1 = multitool.sync('node_modules', 'ramda-fantasy', '0.x');
   const {identity} = require('ramda@0.23.x');
   const {Maybe} = require('ramda-fantasy@0.x');
 
@@ -33,14 +57,32 @@ test('installing an non-existent package should return null', async t => {
   t.is(installed, null);
 });
 
+test('synchronously installing an non-existent package should return null', t => {
+  const installed = multitool.sync('node_modules', 'doesnt-exist', '0.0.0');
+
+  t.is(installed, null);
+});
+
 test('installing an non-existent package version should return null', async t => {
   const installed = await multitool('node_modules', 'ramda', '99.99.99');
 
   t.is(installed, null);
 });
 
+test('synchronously installing an non-existent package version should return null', t => {
+  const installed = multitool.sync('node_modules', 'ramda', '99.99.99');
+
+  t.is(installed, null);
+});
+
 test('installing an invalidly named package should return null', async t => {
   const installed = await multitool('node_modules', 'ramda', '>=99.99.99');
+
+  t.is(installed, null);
+});
+
+test('synchronously installing an invalidly named package should return null', t => {
+  const installed = multitool.sync('node_modules', 'ramda', '>=99.99.99');
 
   t.is(installed, null);
 });

--- a/test/index.js
+++ b/test/index.js
@@ -1,1 +1,10 @@
 'use strict';
+
+const test = require('ava');
+const multitool = require('../src');
+
+test(async t => {
+  const install = await multitool('node_modules', 'ramda', '0.23.0');
+
+  t.is(install, 'ramda-0.23.0');
+});

--- a/test/index.js
+++ b/test/index.js
@@ -4,8 +4,8 @@ const test = require('ava');
 const multitool = require('../src');
 
 test.serial('installing a valid package with an exact version should work', async t => {
-  const installed0 = await multitool('node_modules', 'ramda', '0.23.0');
-  const installed1 = await multitool('node_modules', 'ramda-fantasy', '0.7.0');
+  const installed0 = await multitool('ramda', '0.23.0', 'node_modules');
+  const installed1 = await multitool('ramda-fantasy', '0.7.0', 'node_modules');
   const {identity} = require('ramda@0.23.0');
   const {Maybe} = require('ramda-fantasy@0.7.0');
 
@@ -16,8 +16,8 @@ test.serial('installing a valid package with an exact version should work', asyn
 });
 
 test.serial('installing a valid package with an x-based query should work', async t => {
-  const installed0 = await multitool('node_modules', 'ramda', '0.23.x');
-  const installed1 = await multitool('node_modules', 'ramda-fantasy', '0.x');
+  const installed0 = await multitool('ramda', '0.23.x', 'node_modules');
+  const installed1 = await multitool('ramda-fantasy', '0.x', 'node_modules');
   const {identity} = require('ramda@0.23.x');
   const {Maybe} = require('ramda-fantasy@0.x');
 
@@ -28,19 +28,19 @@ test.serial('installing a valid package with an x-based query should work', asyn
 });
 
 test.serial('installing an non-existent package should return null', async t => {
-  const installed = await multitool('node_modules', 'doesnt-exist', '0.0.0');
+  const installed = await multitool('doesnt-exist', '0.0.0', 'node_modules');
 
   t.is(installed, null);
 });
 
 test.serial('installing an non-existent package version should return null', async t => {
-  const installed = await multitool('node_modules', 'ramda', '99.99.99');
+  const installed = await multitool('ramda', '99.99.99', 'node_modules');
 
   t.is(installed, null);
 });
 
 test.serial('installing an invalidly named package should return null', async t => {
-  const installed = await multitool('node_modules', 'ramda', '>=99.99.99');
+  const installed = await multitool('ramda', '>=99.99.99', 'node_modules');
 
   t.is(installed, null);
 });

--- a/test/index.js
+++ b/test/index.js
@@ -6,12 +6,12 @@ const multitool = require('../src');
 test('installing a valid package with an exact version should return new package name', async t => {
   const install = await multitool('node_modules', 'ramda', '0.23.0');
 
-  t.is(install, 'ramda-0.23.0');
+  t.is(install, 'ramda@0.23.0');
 });
 
 test('installing a valid package with an exact version should work', async t => {
   await multitool('node_modules', 'ramda', '0.23.0');
-  const {identity} = require('ramda-0.23.0');
+  const {identity} = require('ramda@0.23.0');
 
   t.is(identity('hello'), 'hello');
 });

--- a/test/index.js
+++ b/test/index.js
@@ -4,8 +4,8 @@ const test = require('ava');
 const multitool = require('../src');
 
 test.serial('installing a valid package with an exact version should work', async t => {
-  const installed0 = await multitool('ramda', '0.23.0', 'node_modules');
-  const installed1 = await multitool('ramda-fantasy', '0.7.0', 'node_modules');
+  const installed0 = await multitool('ramda', '0.23.0');
+  const installed1 = await multitool('ramda-fantasy', '0.7.0');
   const {identity} = require('ramda@0.23.0');
   const {Maybe} = require('ramda-fantasy@0.7.0');
 
@@ -16,8 +16,8 @@ test.serial('installing a valid package with an exact version should work', asyn
 });
 
 test.serial('installing a valid package with an x-based query should work', async t => {
-  const installed0 = await multitool('ramda', '0.23.x', 'node_modules');
-  const installed1 = await multitool('ramda-fantasy', '0.x', 'node_modules');
+  const installed0 = await multitool('ramda', '0.23.x');
+  const installed1 = await multitool('ramda-fantasy', '0.x');
   const {identity} = require('ramda@0.23.x');
   const {Maybe} = require('ramda-fantasy@0.x');
 
@@ -27,20 +27,28 @@ test.serial('installing a valid package with an x-based query should work', asyn
   t.true(Maybe.isNothing(Maybe.Nothing()));
 });
 
+test.serial('installing with an explicit path should work', async t => {
+  const installed = await multitool('ramda', '0.23.x', 'node_modules');
+  const {identity} = require('ramda@0.23.x');
+
+  t.is(installed, 'ramda@0.23.x');
+  t.is(identity('hello'), 'hello');
+});
+
 test.serial('installing an non-existent package should return null', async t => {
-  const installed = await multitool('doesnt-exist', '0.0.0', 'node_modules');
+  const installed = await multitool('doesnt-exist', '0.0.0');
 
   t.is(installed, null);
 });
 
 test.serial('installing an non-existent package version should return null', async t => {
-  const installed = await multitool('ramda', '99.99.99', 'node_modules');
+  const installed = await multitool('ramda', '99.99.99');
 
   t.is(installed, null);
 });
 
 test.serial('installing an invalidly named package should return null', async t => {
-  const installed = await multitool('ramda', '>=99.99.99', 'node_modules');
+  const installed = await multitool('ramda', '>=99.99.99');
 
   t.is(installed, null);
 });

--- a/test/index.js
+++ b/test/index.js
@@ -3,7 +3,7 @@
 const test = require('ava');
 const multitool = require('../src');
 
-test('installing a valid package with an exact version should work', async t => {
+test.serial('installing a valid package with an exact version should work', async t => {
   const installed0 = await multitool('node_modules', 'ramda', '0.23.0');
   const installed1 = await multitool('node_modules', 'ramda-fantasy', '0.7.0');
   const {identity} = require('ramda@0.23.0');
@@ -15,7 +15,7 @@ test('installing a valid package with an exact version should work', async t => 
   t.true(Maybe.isNothing(Maybe.Nothing()));
 });
 
-test('synchronously installing a valid package with an exact version should work', t => {
+test.serial('synchronously installing a valid package with an exact version should work', t => {
   const installed0 = multitool.sync('node_modules', 'ramda', '0.23.0');
   const installed1 = multitool.sync('node_modules', 'ramda-fantasy', '0.7.0');
   const {identity} = require('ramda@0.23.0');
@@ -27,7 +27,7 @@ test('synchronously installing a valid package with an exact version should work
   t.true(Maybe.isNothing(Maybe.Nothing()));
 });
 
-test('installing a valid package with an x-based query should work', async t => {
+test.serial('installing a valid package with an x-based query should work', async t => {
   const installed0 = await multitool('node_modules', 'ramda', '0.23.x');
   const installed1 = await multitool('node_modules', 'ramda-fantasy', '0.x');
   const {identity} = require('ramda@0.23.x');
@@ -39,7 +39,7 @@ test('installing a valid package with an x-based query should work', async t => 
   t.true(Maybe.isNothing(Maybe.Nothing()));
 });
 
-test('synchronously installing a valid package with an x-based query should work', t => {
+test.serial('synchronously installing a valid package with an x-based query should work', t => {
   const installed0 = multitool.sync('node_modules', 'ramda', '0.23.x');
   const installed1 = multitool.sync('node_modules', 'ramda-fantasy', '0.x');
   const {identity} = require('ramda@0.23.x');
@@ -51,37 +51,37 @@ test('synchronously installing a valid package with an x-based query should work
   t.true(Maybe.isNothing(Maybe.Nothing()));
 });
 
-test('installing an non-existent package should return null', async t => {
+test.serial('installing an non-existent package should return null', async t => {
   const installed = await multitool('node_modules', 'doesnt-exist', '0.0.0');
 
   t.is(installed, null);
 });
 
-test('synchronously installing an non-existent package should return null', t => {
+test.serial('synchronously installing an non-existent package should return null', t => {
   const installed = multitool.sync('node_modules', 'doesnt-exist', '0.0.0');
 
   t.is(installed, null);
 });
 
-test('installing an non-existent package version should return null', async t => {
+test.serial('installing an non-existent package version should return null', async t => {
   const installed = await multitool('node_modules', 'ramda', '99.99.99');
 
   t.is(installed, null);
 });
 
-test('synchronously installing an non-existent package version should return null', t => {
+test.serial('synchronously installing an non-existent package version should return null', t => {
   const installed = multitool.sync('node_modules', 'ramda', '99.99.99');
 
   t.is(installed, null);
 });
 
-test('installing an invalidly named package should return null', async t => {
+test.serial('installing an invalidly named package should return null', async t => {
   const installed = await multitool('node_modules', 'ramda', '>=99.99.99');
 
   t.is(installed, null);
 });
 
-test('synchronously installing an invalidly named package should return null', t => {
+test.serial('synchronously installing an invalidly named package should return null', t => {
   const installed = multitool.sync('node_modules', 'ramda', '>=99.99.99');
 
   t.is(installed, null);

--- a/test/index.js
+++ b/test/index.js
@@ -3,20 +3,44 @@
 const test = require('ava');
 const multitool = require('../src');
 
-test('installing a valid package with an exact version should return new package name', async t => {
-  const install0 = await multitool('node_modules', 'ramda', '0.23.0');
-  const install1 = await multitool('node_modules', 'ramda-fantasy', '0.7.0');
-
-  t.is(install0, 'ramda@0.23.0');
-  t.is(install1, 'ramda-fantasy@0.7.0');
-});
-
 test('installing a valid package with an exact version should work', async t => {
-  await multitool('node_modules', 'ramda', '0.23.0');
-  await multitool('node_modules', 'ramda-fantasy', '0.7.0');
+  const installed0 = await multitool('node_modules', 'ramda', '0.23.0');
+  const installed1 = await multitool('node_modules', 'ramda-fantasy', '0.7.0');
   const {identity} = require('ramda@0.23.0');
   const {Maybe} = require('ramda-fantasy@0.7.0');
 
+  t.is(installed0, 'ramda@0.23.0');
+  t.is(installed1, 'ramda-fantasy@0.7.0');
   t.is(identity('hello'), 'hello');
   t.true(Maybe.isNothing(Maybe.Nothing()));
+});
+
+test('installing a valid package with an x-based query should work', async t => {
+  const installed0 = await multitool('node_modules', 'ramda', '0.23.x');
+  const installed1 = await multitool('node_modules', 'ramda-fantasy', '0.x');
+  const {identity} = require('ramda@0.23.x');
+  const {Maybe} = require('ramda-fantasy@0.x');
+
+  t.is(installed0, 'ramda@0.23.x');
+  t.is(installed1, 'ramda-fantasy@0.x');
+  t.is(identity('hello'), 'hello');
+  t.true(Maybe.isNothing(Maybe.Nothing()));
+});
+
+test('installing an non-existent package should return null', async t => {
+  const installed = await multitool('node_modules', 'doesnt-exist', '0.0.0');
+
+  t.is(installed, null);
+});
+
+test('installing an non-existent package version should return null', async t => {
+  const installed = await multitool('node_modules', 'ramda', '99.99.99');
+
+  t.is(installed, null);
+});
+
+test('installing an invalidly named package should return null', async t => {
+  const installed = await multitool('node_modules', 'ramda', '>=99.99.99');
+
+  t.is(installed, null);
 });

--- a/test/index.js
+++ b/test/index.js
@@ -7,15 +7,15 @@ test('installing a valid package with an exact version should return new package
   const install0 = await multitool('node_modules', 'ramda', '0.23.0');
   const install1 = await multitool('node_modules', 'ramda-fantasy', '0.7.0');
 
-  t.is(install0, 'ramda-0.23.0');
-  t.is(install1, 'ramda-fantasy-0.7.0');
+  t.is(install0, 'ramda@0.23.0');
+  t.is(install1, 'ramda-fantasy@0.7.0');
 });
 
 test('installing a valid package with an exact version should work', async t => {
   await multitool('node_modules', 'ramda', '0.23.0');
   await multitool('node_modules', 'ramda-fantasy', '0.7.0');
-  const {identity} = require('ramda-0.23.0');
-  const {Maybe} = require('ramda-fantasy-0.7.0');
+  const {identity} = require('ramda@0.23.0');
+  const {Maybe} = require('ramda-fantasy@0.7.0');
 
   t.is(identity('hello'), 'hello');
   t.true(Maybe.isNothing(Maybe.Nothing()));

--- a/test/index.js
+++ b/test/index.js
@@ -4,14 +4,19 @@ const test = require('ava');
 const multitool = require('../src');
 
 test('installing a valid package with an exact version should return new package name', async t => {
-  const install = await multitool('node_modules', 'ramda', '0.23.0');
+  const install0 = await multitool('node_modules', 'ramda', '0.23.0');
+  const install1 = await multitool('node_modules', 'ramda-fantasy', '0.7.0');
 
-  t.is(install, 'ramda@0.23.0');
+  t.is(install0, 'ramda-0.23.0');
+  t.is(install1, 'ramda-fantasy-0.7.0');
 });
 
 test('installing a valid package with an exact version should work', async t => {
   await multitool('node_modules', 'ramda', '0.23.0');
-  const {identity} = require('ramda@0.23.0');
+  await multitool('node_modules', 'ramda-fantasy', '0.7.0');
+  const {identity} = require('ramda-0.23.0');
+  const {Maybe} = require('ramda-fantasy-0.7.0');
 
   t.is(identity('hello'), 'hello');
+  t.true(Maybe.isNothing(Maybe.Nothing()));
 });


### PR DESCRIPTION
## Description
Baseline implementation which allows one to dynamically install any NPM package in a mutli-version friendly manner:

```javascript
const multitool = require('multi-tool');

await multitool('ramda', '0.23.0');
await multitool('ramda', '0.23.x');

const ramda0230 = require('ramda@0.23.0');
const ramda023x = require('ramda@0.23.x');
```