### PR TITLE
Fix missing await on rmdir upon error

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -42,7 +42,7 @@ const install = async (name, version, path) => {
     return `${name}@${version}`;
   } catch (err) {
     try {
-      rmdir(dir);
+      await rmdir(dir);
     } catch (err) { }
 
     return null;


### PR DESCRIPTION
## Description
Adds a missing `await` to cleanup the attempted install when an error was encountered.