### PR TITLE
Validate

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
     "execa": "0.6.x",
     "findup-sync": "0.4.x",
     "fs-extra": "2.x",
+    "path-exists": "3.x",
     "pify": "2.x",
     "ramda": "0.23.x",
     "semver": "5.x",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,8 @@
     "findup-sync": "0.4.x",
     "fs-extra": "2.x",
     "pify": "2.x",
+    "ramda": "0.23.x",
+    "semver": "5.x",
     "valid-filename": "2.x"
   },
   "description": "Install multiple versions of NPM packages via semver ranges",

--- a/src/index.js
+++ b/src/index.js
@@ -4,6 +4,7 @@ const pth = require('path');
 const execa = require('execa');
 const findup = require('findup-sync');
 const fs = require('fs-extra');
+const exists = require('path-exists');
 const pify = require('pify');
 const {allPass, is, test} = require('ramda');
 const semver = require('semver');
@@ -35,6 +36,10 @@ const install = async (name, version, path) => {
 
   if (!path) {
     path = findup('node_modules', {cwd: module.parent.filename});
+  }
+
+  if (!(await exists(path))) {
+    return '';
   }
 
   const dir = pth.join(path, `${name}@${version}`);

--- a/src/index.js
+++ b/src/index.js
@@ -5,6 +5,8 @@ const execa = require('execa');
 const findup = require('findup-sync');
 const fs = require('fs-extra');
 const pify = require('pify');
+const {allPass, is, test} = require('ramda');
+const semver = require('semver');
 const validFilename = require('valid-filename');
 
 const mkdir = pify(fs.mkdirp);
@@ -12,8 +14,22 @@ const rmdir = pify(fs.remove);
 const shell = execa.shell;
 const write = pify(fs.outputFile);
 
+const lenUnder = n => str => str.length < n;
+
+const validName = allPass([
+  is(String),
+  lenUnder(215),
+  test(/^(?:@([^/]+?)[/])?([^/]+?)$/)
+]);
+
+const validVersion = allPass([
+  is(String),
+  validFilename,
+  ver => semver.validRange(ver)
+]);
+
 const install = async (name, version, path) => {
-  if (!validFilename(`${name}@${version}`)) {
+  if (!validName(name) || !validVersion(version)) {
     return '';
   }
 
@@ -50,3 +66,5 @@ const install = async (name, version, path) => {
 };
 
 module.exports = install;
+module.exports.validName = validName;
+module.exports.validVersion = validVersion;

--- a/test/index.js
+++ b/test/index.js
@@ -1,11 +1,11 @@
 'use strict';
 
 const test = require('ava');
-const multitool = require('../src');
+const install = require('../src');
 
 test.serial('installing a valid package with an exact version should work', async t => {
-  const installed0 = await multitool('ramda', '0.23.0');
-  const installed1 = await multitool('ramda-fantasy', '0.7.0');
+  const installed0 = await install('ramda', '0.23.0');
+  const installed1 = await install('ramda-fantasy', '0.7.0');
   const {identity} = require('ramda@0.23.0');
   const {Maybe} = require('ramda-fantasy@0.7.0');
 
@@ -16,8 +16,8 @@ test.serial('installing a valid package with an exact version should work', asyn
 });
 
 test.serial('installing a valid package with an x-based query should work', async t => {
-  const installed0 = await multitool('ramda', '0.23.x');
-  const installed1 = await multitool('ramda-fantasy', '0.x');
+  const installed0 = await install('ramda', '0.23.x');
+  const installed1 = await install('ramda-fantasy', '0.x');
   const {identity} = require('ramda@0.23.x');
   const {Maybe} = require('ramda-fantasy@0.x');
 
@@ -28,7 +28,7 @@ test.serial('installing a valid package with an x-based query should work', asyn
 });
 
 test.serial('installing with an explicit path should work', async t => {
-  const installed = await multitool('ramda', '0.23.x', 'node_modules');
+  const installed = await install('ramda', '0.23.x', 'node_modules');
   const {identity} = require('ramda@0.23.x');
 
   t.is(installed, 'ramda@0.23.x');
@@ -36,25 +36,25 @@ test.serial('installing with an explicit path should work', async t => {
 });
 
 test.serial('installing with an invalid explicit path should return an empty String', async t => {
-  const installed = await multitool('ramda', '0.23.x', 'foo');
+  const installed = await install('ramda', '0.23.x', 'foo');
 
   t.is(installed, '');
 });
 
 test.serial('installing an non-existent package should return an empty String', async t => {
-  const installed = await multitool('doesnt-exist', '0.0.0');
+  const installed = await install('doesnt-exist', '0.0.0');
 
   t.is(installed, '');
 });
 
 test.serial('installing an non-existent package version should return an empty String', async t => {
-  const installed = await multitool('ramda', '99.99.99');
+  const installed = await install('ramda', '99.99.99');
 
   t.is(installed, '');
 });
 
 test.serial('installing an invalidly named package should return an empty String', async t => {
-  const installed = await multitool('ramda', '>=99.99.99');
+  const installed = await install('ramda', '>=99.99.99');
 
   t.is(installed, '');
 });

--- a/test/index.js
+++ b/test/index.js
@@ -35,6 +35,12 @@ test.serial('installing with an explicit path should work', async t => {
   t.is(identity('hello'), 'hello');
 });
 
+test.serial('installing with an invalid explicit path should return an empty String', async t => {
+  const installed = await multitool('ramda', '0.23.x', 'foo');
+
+  t.is(installed, '');
+});
+
 test.serial('installing an non-existent package should return an empty String', async t => {
   const installed = await multitool('doesnt-exist', '0.0.0');
 


### PR DESCRIPTION
## Description
Add strict package name and package version checks, all of which adhere to NPM rules and fall just short of actually calling out to NPM to ensure the package/version exists (that is performed lazily already). Additionally, export `validName` and `validVersion` functions which allows users to check things without attempting an install.